### PR TITLE
feat: add screen sharing to /spaces audio rooms

### DIFF
--- a/src/app/spaces/MyControlsPanel.tsx
+++ b/src/app/spaces/MyControlsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { MyLiveButton } from "./MyLiveButton";
 import { MyMicButton } from "./MyMicButton";
+import { MyScreenShareButton } from "./MyScreenShareButton";
 
 export const MyControlsPanel = () => {
     return (
@@ -9,6 +10,7 @@ export const MyControlsPanel = () => {
             <div className="max-w-4xl mx-auto">
                 <div className="flex items-center justify-center gap-4">
                     <MyMicButton />
+                    <MyScreenShareButton />
                     <MyLiveButton />
                 </div>
             </div>

--- a/src/app/spaces/MyScreenShareButton.tsx
+++ b/src/app/spaces/MyScreenShareButton.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useCallStateHooks, useCall, OwnCapability } from '@stream-io/video-react-sdk';
+import { useState, useEffect } from 'react';
+
+export const MyScreenShareButton = () => {
+    const { useScreenShareState, useHasPermissions } = useCallStateHooks();
+    const { screenShare, isMute: isScreenShareOff } = useScreenShareState();
+    const hasPermission = useHasPermissions(OwnCapability.SCREENSHARE);
+    const call = useCall();
+
+    const [isRequesting, setIsRequesting] = useState(false);
+
+    useEffect(() => {
+        if (hasPermission) {
+            setIsRequesting(false);
+        }
+    }, [hasPermission]);
+
+    const handleClick = async () => {
+        if (hasPermission) {
+            try {
+                await screenShare.toggle();
+            } catch (err) {
+                console.error('Screen share failed', err);
+            }
+        } else {
+            if (isRequesting) return;
+            setIsRequesting(true);
+            try {
+                await call?.requestPermissions({ permissions: [OwnCapability.SCREENSHARE] });
+            } catch (err) {
+                console.error('Failed to request screen share permission', err);
+                setIsRequesting(false);
+            }
+        }
+    };
+
+    return (
+        <button
+            onClick={handleClick}
+            disabled={isRequesting && !hasPermission}
+            className={`
+                flex items-center gap-3 px-6 py-3 rounded-xl font-semibold transition-all duration-200
+                ${!hasPermission && isRequesting
+                    ? 'bg-yellow-500/20 text-yellow-500 border border-yellow-500/30 cursor-wait'
+                    : !isScreenShareOff
+                        ? 'bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 text-white shadow-lg shadow-blue-500/20'
+                        : 'bg-muted hover:bg-muted/80 text-foreground border border-border'
+                }
+            `}
+        >
+            {!hasPermission ? (
+                isRequesting ? (
+                    <>
+                        <svg className="w-5 h-5 animate-pulse" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <span>Requesting...</span>
+                    </>
+                ) : (
+                    <>
+                        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                        </svg>
+                        <span>Request Share</span>
+                    </>
+                )
+            ) : !isScreenShareOff ? (
+                <>
+                    <div className="relative flex items-center">
+                        <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
+                    </div>
+                    <span>Stop Sharing</span>
+                </>
+            ) : (
+                <>
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                    <span>Share Screen</span>
+                </>
+            )}
+        </button>
+    );
+};

--- a/src/app/spaces/MyUILayout.tsx
+++ b/src/app/spaces/MyUILayout.tsx
@@ -3,6 +3,7 @@
 import { MyControlsPanel } from "./MyControlsPanel";
 import { MyDescriptionPanel } from "./MyDiscriptionPanel";
 import { MyParticipantsPanel } from "./MyParticipantsPanel";
+import { ScreenShareView } from "./ScreenShareView";
 
 export const MyUILayout = () => {
     return (
@@ -11,6 +12,9 @@ export const MyUILayout = () => {
             <div className="border-b border-border bg-card/30 backdrop-blur-sm">
                 <MyDescriptionPanel />
             </div>
+
+            {/* Screen Share View - Only renders when someone is sharing */}
+            <ScreenShareView />
 
             {/* Participants Panel - Center (Scrollable) */}
             <div className="flex-1 overflow-y-auto">

--- a/src/app/spaces/ScreenShareView.tsx
+++ b/src/app/spaces/ScreenShareView.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useCallStateHooks, ParticipantView, SfuModels } from '@stream-io/video-react-sdk';
+
+export const ScreenShareView = () => {
+    const { useParticipants } = useCallStateHooks();
+    const participants = useParticipants();
+
+    const screenSharer = participants.find((p) =>
+        p.publishedTracks.includes(SfuModels.TrackType.SCREEN_SHARE)
+    );
+
+    if (!screenSharer) return null;
+
+    return (
+        <div className="border-b border-border bg-card/30 backdrop-blur-sm">
+            <div className="max-w-4xl mx-auto p-4">
+                <div className="flex items-center gap-2 mb-2">
+                    <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse" />
+                    <span className="text-sm text-blue-400 font-medium">
+                        {screenSharer.name || 'Someone'} is sharing their screen
+                    </span>
+                </div>
+                <div className="aspect-video rounded-xl overflow-hidden bg-black">
+                    <ParticipantView
+                        participant={screenSharer}
+                        trackType="screenShareTrack"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
## Summary
- Add screen share support to `/spaces` audio rooms using Stream Video SDK's built-in `screenshare` capability
- Follows the existing `MyMicButton`/`MyLiveButton` pattern for consistency — no new dependencies needed
- Screen share view renders above participants panel when someone is sharing

## Changes
- **New:** `MyScreenShareButton.tsx` — toggle screen share with permission request flow (matches MyMicButton UX pattern)
- **New:** `ScreenShareView.tsx` — displays shared screen in 16:9 aspect ratio above participants
- **Modified:** `MyControlsPanel.tsx` — added screen share button between mic and live buttons
- **Modified:** `MyUILayout.tsx` — added ScreenShareView slot between description and participants panels

## Requirements
- Enable `screenshare` capability on the Stream call type in [Stream Dashboard](https://dashboard.getstream.io/) for `host` and `speaker` roles
- Desktop browsers only (mobile does not support `getDisplayMedia`)

## Use Cases
- Music producers sharing DAW sessions during listening parties
- Visual artists sharing screens during creative sessions
- Presenters sharing slides during community calls

## Test plan
- [ ] Enable `screenshare` capability on Stream call type
- [ ] Verify "Share Screen" button appears in controls panel
- [ ] Test screen share start/stop flow
- [ ] Verify shared screen renders for other participants in ScreenShareView
- [ ] Test permission request flow for non-host/speaker roles
- [ ] Verify no regressions in mic/live button functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code) — contributed by [@bettercallzaal](https://warpcast.com/bettercallzaal)