### PR TITLE
feat: add screen sharing to /zabal LiveAudioRoom

### DIFF
--- a/src/components/LiveAudioRoom.tsx
+++ b/src/components/LiveAudioRoom.tsx
@@ -12,6 +12,8 @@ import {
     selectLocalPeer,
     selectRoomState,
     selectDominantSpeaker,
+    selectPeerScreenSharing,
+    selectScreenShareByPeerID,
     HMSRoomState,
     useTranscript,
     selectIsTranscriptionEnabled,
@@ -442,6 +444,8 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
     const localPeer = useHMSStore(selectLocalPeer);
     const isAudioEnabled = useHMSStore(selectIsPeerAudioEnabled(localPeer?.id || ''));
     const dominantSpeaker = useHMSStore(selectDominantSpeaker);
+    const screenSharingPeer = useHMSStore(selectPeerScreenSharing);
+    const screenShareTrack = useHMSStore(selectScreenShareByPeerID(screenSharingPeer?.id || ''));
     const messages = useHMSStore(selectHMSMessages);
     const { user, authenticated, login, twitterObj } = useAuth();
 
@@ -964,6 +968,14 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
         await hmsActions.setLocalAudioEnabled(!isAudioEnabled);
     };
 
+    const handleToggleScreenShare = async () => {
+        try {
+            await hmsActions.setScreenShareEnabled(!screenSharingPeer?.isLocal);
+        } catch (err) {
+            console.error('Screen share failed:', err);
+        }
+    };
+
     const handleLeave = async () => {
         await hmsActions.leave();
     };
@@ -1272,6 +1284,33 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
                     )}
                 </AnimatePresence>
 
+                {/* Screen Share Display */}
+                {screenSharingPeer && screenShareTrack && (
+                    <motion.div
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        exit={{ opacity: 0, height: 0 }}
+                        className="mb-4 rounded-2xl overflow-hidden bg-black ring-1 ring-white/10"
+                    >
+                        <div className="flex items-center gap-2 px-4 py-2 bg-blue-500/10 border-b border-blue-500/20">
+                            <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse" />
+                            <span className="text-xs text-blue-400 font-medium">
+                                {screenSharingPeer.name || 'Someone'} is sharing their screen
+                            </span>
+                        </div>
+                        <video
+                            ref={(el) => {
+                                if (el && screenShareTrack?.id) {
+                                    hmsActions.attachVideo(screenShareTrack.id, el);
+                                }
+                            }}
+                            autoPlay
+                            playsInline
+                            className="w-full max-h-[50vh] object-contain"
+                        />
+                    </motion.div>
+                )}
+
                 <div className="relative group rounded-2xl">
                     {/* Animated Gradient Border / Glow */}
                     <div className="absolute -inset-1 bg-gradient-to-r from-cyan-500 via-purple-500 to-cyan-500 rounded-2xl blur opacity-75 group-hover:opacity-100 transition duration-1000 group-hover:duration-200 animate-gradient-x"></div>
@@ -1297,6 +1336,8 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
                             onLeave={handleLeave}
                             onEndRoom={handleEndRoom}
                             onToggleMic={handleToggleMic}
+                            onToggleScreenShare={handleToggleScreenShare}
+                            isScreenSharing={!!screenSharingPeer?.isLocal}
                             onRaiseHand={handleRaiseHand}
                             onLogin={login}
                             onApproveRequest={handleApproveRequest}

--- a/src/components/MiniSpaceBanner.tsx
+++ b/src/components/MiniSpaceBanner.tsx
@@ -96,6 +96,8 @@ interface MiniSpaceBannerProps {
     isRecordingOn?: boolean;
     onToggleRecording?: () => void;
     sessionPoints?: number;
+    onToggleScreenShare?: () => void;
+    isScreenSharing?: boolean;
 }
 
 export default function MiniSpaceBanner({
@@ -130,7 +132,9 @@ export default function MiniSpaceBanner({
     onMuteAll,
     isRecordingOn = false,
     onToggleRecording,
-    sessionPoints = 0
+    sessionPoints = 0,
+    onToggleScreenShare,
+    isScreenSharing = false
 }: MiniSpaceBannerProps) {
     const [showRequests, setShowRequests] = React.useState(false);
     const [showSpeakers, setShowSpeakers] = React.useState(false);
@@ -386,6 +390,22 @@ export default function MiniSpaceBanner({
                             >
                                 <span className="text-sm font-bold">CC</span>
                             </button>
+
+                            {/* Screen Share Toggle */}
+                            {(isHost || isSpeaker) && onToggleScreenShare && (
+                                <button
+                                    onClick={onToggleScreenShare}
+                                    className={`p-2 rounded-full transition-all ${isScreenSharing
+                                        ? 'bg-blue-500 text-white shadow-lg shadow-blue-500/30'
+                                        : 'bg-white/10 hover:bg-white/20 text-white'
+                                        }`}
+                                    title={isScreenSharing ? "Stop Sharing" : "Share Screen"}
+                                >
+                                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                                    </svg>
+                                </button>
+                            )}
 
                             {/* Host: Recording Toggle */}
                             {/* {isHost && onToggleRecording && (


### PR DESCRIPTION
## Context
Closed PR #17 (targeted the old Stream SDK /spaces route — my mistake). This PR targets the correct components: `LiveAudioRoom` + `MiniSpaceBanner` that power the `/zabal` leaderboard page.

We're building [ZAO OS](https://github.com/bettercallzaal) — a gated Farcaster client for The ZAO music community. We embed `songjam.space/zabal` as an iframe in our app so members can join audio spaces without leaving ZAO OS. Adding screen share would let music producers share DAW sessions and artists share visuals during listening parties.

## Summary
Add screen sharing to the 100ms-based `LiveAudioRoom` component using `hmsActions.setScreenShareEnabled()` — no new dependencies.

## Changes (2 files, 62 lines added)

**`src/components/LiveAudioRoom.tsx`:**
- Added `selectPeerScreenSharing` + `selectScreenShareByPeerID` selectors from 100ms SDK
- `handleToggleScreenShare` handler using `hmsActions.setScreenShareEnabled()`
- Screen share video display above MiniSpaceBanner — renders when any participant shares, uses `hmsActions.attachVideo()` to bind the track
- Passes `onToggleScreenShare` + `isScreenSharing` props to MiniSpaceBanner

**`src/components/MiniSpaceBanner.tsx`:**
- New optional props: `onToggleScreenShare`, `isScreenSharing`
- Screen share toggle button (monitor icon) — visible for host and speakers only, placed between caption toggle and recording toggle

## How it works
- Host/speaker taps the monitor icon → `hmsActions.setScreenShareEnabled(true)` → browser prompts screen picker
- Other participants see the shared screen in a video element above the controls
- Tap again to stop → `hmsActions.setScreenShareEnabled(false)`

## Test plan
- [ ] Verify screen share button appears for host/speaker roles only
- [ ] Test start/stop screen share flow
- [ ] Verify shared screen renders for other participants via `hmsActions.attachVideo()`
- [ ] Verify screen share video disappears when sharing stops
- [ ] Confirm no regressions in mic/caption/recording controls

🤖 Generated with [Claude Code](https://claude.com/claude-code) — contributed by [@bettercallzaal](https://warpcast.com/bettercallzaal)