### PR TITLE
feat: host controls — room settings, co-hosts, speaker timers, mute UI

### DIFF
--- a/src/components/LiveAudioRoom.tsx
+++ b/src/components/LiveAudioRoom.tsx
@@ -47,6 +47,10 @@ import {
     RoomParticipant,
     SpeakerRequest,
     MSRoom,
+    RoomSettings,
+    updateRoomSettings,
+    addCoHost,
+    removeCoHost,
 } from '@/services/db/msRooms.db';
 import { getMusicUploadsByUserId } from '@/services/storage/dj.storage';
 import MiniSpaceBanner from './MiniSpaceBanner';
@@ -502,19 +506,29 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
     // Caption State
     const [showCaptions, setShowCaptions] = useState(false);
 
+    // Speaker Timer — tracks seconds each speaker has been talking
+    const [speakerTimers, setSpeakerTimers] = useState<Record<string, number>>({});
+    const speakerTimerInterval = useRef<NodeJS.Timeout | null>(null);
+
+    // Mute All — inline confirmation replaces window.confirm()
+    const [showMuteAllConfirm, setShowMuteAllConfirm] = useState(false);
+
     // Reaction State
     const [activeReactions, setActiveReactions] = useState<Record<string, { content: string; timestamp: number }>>({});
     const reactionTimeouts = useRef<Record<string, NodeJS.Timeout>>({});
 
     // Check if current user is the host of the active room
-    // This handles the refresh case where user is logged in but not connected to 100ms yet
-    const isHostUser = activeRoom?.hostId === (twitterObj?.twitterId || user?.uid);
+    const currentUserId = twitterObj?.twitterId || user?.uid;
+    const isHostUser = activeRoom?.hostId === currentUserId;
+
+    // Co-host check: user ID is in the coHostIds array
+    const isCoHost = !!(currentUserId && activeRoom?.coHostIds?.includes(currentUserId));
 
     // Check if connected as host role
     const isConnectedHost = localPeer?.roleName?.toLowerCase() === 'host';
 
-    // Effective host check: either connected as host OR is the host user (for re-join UI)
-    const isHost = isConnectedHost || isHostUser;
+    // Effective host check: original host, co-host, or connected with host role
+    const isHost = isConnectedHost || isHostUser || isCoHost;
 
     // Sound Effect for Speaker Requests
     useEffect(() => {
@@ -542,6 +556,34 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
         isSpeaking: isSpeakingForPoints,
         isConnected: isConnected
     });
+
+    // Speaker Timer — auto-reminder when speaker exceeds configured time limit
+    useEffect(() => {
+        if (!isHost || !isConnected) return;
+        const timeLimit = activeRoom?.settings?.speakerTimeLimitSeconds;
+        if (!timeLimit || timeLimit <= 0) return;
+
+        if (speakerTimerInterval.current) clearInterval(speakerTimerInterval.current);
+
+        if (dominantSpeaker && dominantSpeaker.roleName === 'speaker') {
+            const speakerId = dominantSpeaker.id;
+            speakerTimerInterval.current = setInterval(() => {
+                setSpeakerTimers(prev => {
+                    const current = (prev[speakerId] || 0) + 1;
+                    if (current === timeLimit) {
+                        hmsActions.sendBroadcastMessage(
+                            `⏰ @${dominantSpeaker.name} — your ${timeLimit}s speaker time is up!`,
+                            'REACTION'
+                        );
+                    }
+                    return { ...prev, [speakerId]: current };
+                });
+            }, 1000);
+        } else {
+            setSpeakerTimers({});
+        }
+        return () => { if (speakerTimerInterval.current) clearInterval(speakerTimerInterval.current); };
+    }, [dominantSpeaker?.id, isHost, isConnected, activeRoom?.settings?.speakerTimeLimitSeconds]);
 
     // Join Notifications Logic
     useEffect(() => {
@@ -982,6 +1024,34 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
         }
     };
 
+    const handleUpdateRoomSettings = async (settings: Partial<RoomSettings>) => {
+        if (!firestoreRoomId) return;
+        try { await updateRoomSettings(firestoreRoomId, settings); }
+        catch (err) { console.error('Failed to update room settings:', err); }
+    };
+
+    const handleAddCoHost = async (userId: string) => {
+        if (!firestoreRoomId) return;
+        try { await addCoHost(firestoreRoomId, userId); }
+        catch (err) { console.error('Failed to add co-host:', err); }
+    };
+
+    const handleRemoveCoHost = async (userId: string) => {
+        if (!firestoreRoomId) return;
+        try { await removeCoHost(firestoreRoomId, userId); }
+        catch (err) { console.error('Failed to remove co-host:', err); }
+    };
+
+    const handleMuteAllConfirmed = async () => {
+        try {
+            const remoteSpeakers = peers.filter(p => !p.isLocal && p.roleName?.toLowerCase() === 'speaker');
+            for (const speaker of remoteSpeakers) {
+                if (speaker.audioTrack) await hmsActions.setRemoteTrackEnabled(speaker.audioTrack, false);
+            }
+        } catch (err) { console.error('Failed to mute all:', err); }
+        setShowMuteAllConfirm(false);
+    };
+
     const handleLeave = async () => {
         await hmsActions.leave();
     };
@@ -1328,23 +1398,19 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
                             onStopTrack={handleStopTrack}
                             showCaptions={showCaptions}
                             onSendReaction={handleSendReaction}
-                            onMuteAll={async () => {
-                                if (window.confirm("Are you sure you want to mute all speakers?")) {
-                                    try {
-                                        // Get all remote speakers
-                                        const remoteSpeakers = peers.filter(p => !p.isLocal && p.roleName?.toLowerCase() === 'speaker');
-                                        for (const speaker of remoteSpeakers) {
-                                            if (speaker.audioTrack) {
-                                                await hmsActions.setRemoteTrackEnabled(speaker.audioTrack, false);
-                                            }
-                                        }
-                                    } catch (err) {
-                                        console.error("Failed to mute all speakers", err);
-                                    }
-                                }
-                            }}
+                            onMuteAll={() => setShowMuteAllConfirm(true)}
+                            showMuteAllConfirm={showMuteAllConfirm}
+                            onMuteAllConfirmed={handleMuteAllConfirmed}
+                            onMuteAllCancelled={() => setShowMuteAllConfirm(false)}
                             isRecordingOn={!!isRecordingOn}
                             onToggleRecording={handleToggleRecording}
+                            roomSettings={activeRoom?.settings}
+                            onUpdateRoomSettings={handleUpdateRoomSettings}
+                            coHostIds={activeRoom?.coHostIds || []}
+                            onAddCoHost={handleAddCoHost}
+                            onRemoveCoHost={handleRemoveCoHost}
+                            speakerTimers={speakerTimers}
+                            peers={peers}
                             onToggleCaptions={async () => {
                                 const nextState = !showCaptions;
                                 setShowCaptions(nextState);

--- a/src/components/MiniSpaceBanner.tsx
+++ b/src/components/MiniSpaceBanner.tsx
@@ -99,6 +99,16 @@ interface MiniSpaceBannerProps {
     sessionPoints?: number;
     onToggleScreenShare?: () => void;
     isScreenSharing?: boolean;
+    showMuteAllConfirm?: boolean;
+    onMuteAllConfirmed?: () => void;
+    onMuteAllCancelled?: () => void;
+    roomSettings?: { title?: string; description?: string; rules?: string; speakerTimeLimitSeconds?: number };
+    onUpdateRoomSettings?: (settings: Partial<{ title?: string; description?: string; rules?: string; speakerTimeLimitSeconds?: number }>) => void;
+    coHostIds?: string[];
+    onAddCoHost?: (userId: string) => void;
+    onRemoveCoHost?: (userId: string) => void;
+    speakerTimers?: Record<string, number>;
+    peers?: any[];
 }
 
 export default function MiniSpaceBanner({
@@ -136,13 +146,25 @@ export default function MiniSpaceBanner({
     onToggleRecording,
     sessionPoints = 0,
     onToggleScreenShare,
-    isScreenSharing = false
+    isScreenSharing = false,
+    showMuteAllConfirm = false,
+    onMuteAllConfirmed,
+    onMuteAllCancelled,
+    roomSettings,
+    onUpdateRoomSettings,
+    coHostIds = [],
+    onAddCoHost,
+    onRemoveCoHost,
+    speakerTimers = {},
+    peers = []
 }: MiniSpaceBannerProps) {
     const [showRequests, setShowRequests] = React.useState(false);
     const [showSpeakers, setShowSpeakers] = React.useState(false);
     const [showPlaylist, setShowPlaylist] = React.useState(false);
     const [showReactions, setShowReactions] = React.useState(false);
     const [reactionText, setReactionText] = React.useState('');
+    const [showSettingsPanel, setShowSettingsPanel] = React.useState(false);
+    const [coHostInput, setCoHostInput] = React.useState('');
 
 
     // Animation variants
@@ -426,6 +448,99 @@ export default function MiniSpaceBanner({
                                 </button>
                             )} */}
 
+                            {/* Host: Room Settings (title, description, rules, speaker timer, co-hosts) */}
+                            {isHost && onUpdateRoomSettings && (
+                                <div className="relative">
+                                    <button
+                                        onClick={() => setShowSettingsPanel(!showSettingsPanel)}
+                                        className={`p-2 rounded-full transition-all ${showSettingsPanel ? 'bg-white/20 text-white' : 'bg-white/10 hover:bg-white/20 text-white/60'}`}
+                                        title="Room Settings"
+                                    >
+                                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                        </svg>
+                                    </button>
+                                    <AnimatePresence>
+                                        {showSettingsPanel && (
+                                            <motion.div
+                                                initial={{ opacity: 0, y: -10, scale: 0.95 }}
+                                                animate={{ opacity: 1, y: 0, scale: 1 }}
+                                                exit={{ opacity: 0, y: -10, scale: 0.95 }}
+                                                className="fixed top-24 left-2 right-2 sm:absolute sm:top-full sm:right-0 sm:left-auto sm:w-[400px] sm:mt-3 bg-[#1a1a1a] border border-white/10 rounded-xl shadow-2xl overflow-hidden z-[70]"
+                                            >
+                                                <div className="px-4 py-3 bg-white/5 border-b border-white/5">
+                                                    <h3 className="text-xs font-bold text-white/80">Room Settings</h3>
+                                                </div>
+                                                <div className="p-4 space-y-3">
+                                                    <div>
+                                                        <label className="text-[10px] text-white/40 uppercase tracking-wider font-bold">Title</label>
+                                                        <input type="text" defaultValue={roomSettings?.title || ''} placeholder="e.g. Weekly Music Review" maxLength={100}
+                                                            onBlur={(e) => onUpdateRoomSettings({ title: e.target.value })}
+                                                            className="w-full mt-1 bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-white/30" />
+                                                    </div>
+                                                    <div>
+                                                        <label className="text-[10px] text-white/40 uppercase tracking-wider font-bold">Description</label>
+                                                        <textarea defaultValue={roomSettings?.description || ''} placeholder="What's this session about?" maxLength={500} rows={2}
+                                                            onBlur={(e) => onUpdateRoomSettings({ description: e.target.value })}
+                                                            className="w-full mt-1 bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-white/30 resize-none" />
+                                                    </div>
+                                                    <div>
+                                                        <label className="text-[10px] text-white/40 uppercase tracking-wider font-bold">Rules</label>
+                                                        <textarea defaultValue={roomSettings?.rules || ''} placeholder="e.g. Keep feedback constructive, 2 min per speaker" maxLength={300} rows={2}
+                                                            onBlur={(e) => onUpdateRoomSettings({ rules: e.target.value })}
+                                                            className="w-full mt-1 bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-white/30 resize-none" />
+                                                    </div>
+                                                    <div>
+                                                        <label className="text-[10px] text-white/40 uppercase tracking-wider font-bold">Speaker Time Limit</label>
+                                                        <select defaultValue={roomSettings?.speakerTimeLimitSeconds || 0}
+                                                            onChange={(e) => onUpdateRoomSettings({ speakerTimeLimitSeconds: Number(e.target.value) })}
+                                                            className="w-full mt-1 bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-white/30">
+                                                            <option value={0}>No limit</option>
+                                                            <option value={60}>1 minute</option>
+                                                            <option value={120}>2 minutes</option>
+                                                            <option value={180}>3 minutes</option>
+                                                            <option value={300}>5 minutes</option>
+                                                        </select>
+                                                        <p className="text-[10px] text-white/30 mt-1">Auto-reminder sent when a speaker hits the limit</p>
+                                                    </div>
+                                                    <div>
+                                                        <label className="text-[10px] text-white/40 uppercase tracking-wider font-bold">Co-Hosts</label>
+                                                        <p className="text-[10px] text-white/30 mb-2">Co-hosts can mute, approve speakers, and manage the room</p>
+                                                        {coHostIds.length > 0 && (
+                                                            <div className="space-y-1 mb-2">
+                                                                {coHostIds.map((id) => {
+                                                                    const peer = peers.find((p: any) => p.customerUserId === id);
+                                                                    return (
+                                                                        <div key={id} className="flex items-center justify-between bg-white/5 rounded-lg px-3 py-1.5">
+                                                                            <span className="text-xs text-white">{peer?.name || id}</span>
+                                                                            <button onClick={() => onRemoveCoHost?.(id)} className="text-[10px] text-red-400 hover:text-red-300">Remove</button>
+                                                                        </div>
+                                                                    );
+                                                                })}
+                                                            </div>
+                                                        )}
+                                                        {onAddCoHost && (
+                                                            <div className="flex gap-2">
+                                                                <select value={coHostInput} onChange={(e) => setCoHostInput(e.target.value)}
+                                                                    className="flex-1 bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-white/30">
+                                                                    <option value="">Select a speaker...</option>
+                                                                    {peers.filter((p: any) => p.roleName === 'speaker' && !p.isLocal && !coHostIds.includes(p.customerUserId))
+                                                                        .map((p: any) => (<option key={p.id} value={p.customerUserId}>{p.name}</option>))}
+                                                                </select>
+                                                                <button onClick={() => { if (coHostInput) { onAddCoHost(coHostInput); setCoHostInput(''); } }}
+                                                                    disabled={!coHostInput}
+                                                                    className="px-3 bg-white/10 hover:bg-white/20 text-white rounded-lg text-xs font-bold disabled:opacity-30 transition-colors">Add</button>
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            </motion.div>
+                                        )}
+                                    </AnimatePresence>
+                                </div>
+                            )}
+
                             {/* Host: DJ Console */}
                             {isHost && (
                                 <div className="relative">
@@ -546,7 +661,7 @@ export default function MiniSpaceBanner({
                                                 <div className="px-3 py-2 bg-white/5 border-b border-white/5 flex items-center justify-between">
                                                     <h3 className="text-xs font-bold text-white/80">Active Speakers</h3>
                                                     <div className="flex gap-2">
-                                                        {onMuteAll && (
+                                                        {onMuteAll && !showMuteAllConfirm && (
                                                             <button
                                                                 onClick={onMuteAll}
                                                                 className="px-2 py-0.5 bg-red-500/10 hover:bg-red-500 text-red-400 hover:text-white border border-red-500/20 rounded text-[10px] font-bold transition-colors"
@@ -554,6 +669,13 @@ export default function MiniSpaceBanner({
                                                             >
                                                                 Mute All
                                                             </button>
+                                                        )}
+                                                        {showMuteAllConfirm && (
+                                                            <div className="flex items-center gap-1">
+                                                                <span className="text-[10px] text-yellow-400">Mute all?</span>
+                                                                <button onClick={onMuteAllConfirmed} className="px-2 py-0.5 bg-red-500 text-white rounded text-[10px] font-bold">Yes</button>
+                                                                <button onClick={onMuteAllCancelled} className="px-2 py-0.5 bg-white/10 text-white rounded text-[10px] font-bold">No</button>
+                                                            </div>
                                                         )}
                                                     </div>
                                                 </div>

--- a/src/services/db/msRooms.db.ts
+++ b/src/services/db/msRooms.db.ts
@@ -15,6 +15,7 @@ import {
     setDoc,
     increment,
     arrayUnion,
+    arrayRemove,
 } from 'firebase/firestore';
 
 export interface MSRoom {
@@ -30,6 +31,19 @@ export interface MSRoom {
     pinnedLinks?: PinnedItem[];
     isMusicPlaying?: boolean;
     speakers?: SpeakerDetails[];
+    /** Room settings — configurable by host. All optional for backwards compat. */
+    settings?: RoomSettings;
+    /** Co-host user IDs — get host-level controls without being the room creator. */
+    coHostIds?: string[];
+}
+
+/** Room settings stored as a sub-object on the MSRoom Firestore document. */
+export interface RoomSettings {
+    title?: string;
+    description?: string;
+    rules?: string;
+    /** Max seconds a speaker can talk before auto-reminder. 0 = no limit. */
+    speakerTimeLimitSeconds?: number;
 }
 
 export interface SpeakerDetails {
@@ -175,6 +189,28 @@ export async function endMSRoom(roomId: string): Promise<void> {
         console.error('Error ending room:', error);
         throw new Error('Failed to end room');
     }
+}
+
+/** Update room settings. Uses dot-notation merge — only overwrites fields you pass. */
+export async function updateRoomSettings(roomId: string, settings: Partial<RoomSettings>): Promise<void> {
+    const docRef = doc(db, MS_ROOMS_COLLECTION, roomId);
+    const updates: Record<string, any> = {};
+    for (const [key, value] of Object.entries(settings)) {
+        updates[`settings.${key}`] = value;
+    }
+    await updateDoc(docRef, updates);
+}
+
+/** Add a co-host. Uses arrayUnion to prevent duplicates. */
+export async function addCoHost(roomId: string, userId: string): Promise<void> {
+    const docRef = doc(db, MS_ROOMS_COLLECTION, roomId);
+    await updateDoc(docRef, { coHostIds: arrayUnion(userId) });
+}
+
+/** Remove a co-host. Uses arrayRemove for atomic removal. */
+export async function removeCoHost(roomId: string, userId: string): Promise<void> {
+    const docRef = doc(db, MS_ROOMS_COLLECTION, roomId);
+    await updateDoc(docRef, { coHostIds: arrayRemove(userId) });
 }
 
 /**


### PR DESCRIPTION
## Summary
4 host experience improvements (no recording — keeping that disabled to avoid 100ms charges). All backwards-compatible, no migration needed.

1. **Mute All confirmation** — inline Yes/No replaces window.confirm()
2. **Speaker time limit** — 1/2/3/5 min, auto ⏰ broadcast when speaker hits limit
3. **Room settings panel** — gear icon: title, description, rules, time limit
4. **Co-host system** — promote speakers to co-host, they get full host controls

3 files, 245 lines. Targets main (not feat-daily-audio).

## Test plan
- [x] Gear icon → set title, description, rules, speaker time limit
- [x] Speaker time limit → verify ⏰ at configured time
- [ ] Add/remove co-host → verify they get host controls
- [x] Mute All → inline Yes/No instead of browser dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code) — contributed by [@bettercallzaal](https://warpcast.com/bettercallzaal)