### PR TITLE
fix: screen share layout — move above controls, 16:9 aspect ratio

### DIFF
--- a/src/components/LiveAudioRoom.tsx
+++ b/src/components/LiveAudioRoom.tsx
@@ -1290,6 +1290,38 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
                     )}
                 </AnimatePresence>
 
+                {/* Screen Share Display — positioned above controls for maximum visibility */}
+                {screenSharingPeer && screenShareTrack && (
+                    <motion.div
+                        initial={{ opacity: 0, scale: 0.95 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.95 }}
+                        className="mb-4 rounded-2xl overflow-hidden bg-black/90 ring-2 ring-blue-500/30 shadow-2xl shadow-blue-500/10"
+                    >
+                        <div className="flex items-center justify-between px-4 py-2 bg-blue-500/10 border-b border-blue-500/20">
+                            <div className="flex items-center gap-2">
+                                <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse" />
+                                <span className="text-xs text-blue-400 font-medium">
+                                    {screenSharingPeer.name || 'Someone'} is sharing their screen
+                                </span>
+                            </div>
+                            <span className="text-[10px] text-blue-400/60 uppercase tracking-wider font-bold">LIVE</span>
+                        </div>
+                        <div className="relative w-full" style={{ aspectRatio: '16/9', maxHeight: '60vh' }}>
+                            <video
+                                ref={(el) => {
+                                    if (el && screenShareTrack?.id) {
+                                        hmsActions.attachVideo(screenShareTrack.id, el);
+                                    }
+                                }}
+                                autoPlay
+                                playsInline
+                                className="absolute inset-0 w-full h-full object-contain bg-black"
+                            />
+                        </div>
+                    </motion.div>
+                )}
+
                 <div className="relative group rounded-2xl">
                     {/* Animated Gradient Border / Glow */}
                     <div className="absolute -inset-1 bg-gradient-to-r from-cyan-500 via-purple-500 to-cyan-500 rounded-2xl blur opacity-75 group-hover:opacity-100 transition duration-1000 group-hover:duration-200 animate-gradient-x"></div>
@@ -1375,32 +1407,7 @@ const LiveAudioRoomInner = ({ projectId }: { projectId: string }) => {
                 </div>
             </div>
 
-                {/* Screen Share Display */}
-                {screenSharingPeer && screenShareTrack && (
-                    <motion.div
-                        initial={{ opacity: 0, height: 0 }}
-                        animate={{ opacity: 1, height: 'auto' }}
-                        exit={{ opacity: 0, height: 0 }}
-                        className="mb-4 rounded-2xl overflow-hidden bg-black ring-1 ring-white/10"
-                    >
-                        <div className="flex items-center gap-2 px-4 py-2 bg-blue-500/10 border-b border-blue-500/20">
-                            <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse" />
-                            <span className="text-xs text-blue-400 font-medium">
-                                {screenSharingPeer.name || 'Someone'} is sharing their screen
-                            </span>
-                        </div>
-                        <video
-                            ref={(el) => {
-                                if (el && screenShareTrack?.id) {
-                                    hmsActions.attachVideo(screenShareTrack.id, el);
-                                }
-                            }}
-                            autoPlay
-                            playsInline
-                            className="w-full max-h-[50vh] object-contain"
-                        />
-                    </motion.div>
-                )}
+                {/* Screen share display moved above MiniSpaceBanner for better visibility */}
 
             {/* Captions Overlay */}
             <AnimatePresence>


### PR DESCRIPTION
## Problem
Screen share video was positioned below the MiniSpaceBanner controls, making it small and hard to see (screenshot shows it crammed at the bottom).

## Fix
- **Moved screen share ABOVE the controls** — it's now the first thing you see when someone shares
- **16:9 aspect ratio container** with `max-height: 60vh` — proper video proportions
- **Absolute positioned video** inside the container — scales correctly without distortion
- **Blue ring glow + shadow** — visually distinct from the dark background
- **LIVE badge** in the header bar
- **Smoother animation** — fade+scale instead of height collapse

1 file, 33 lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — contributed by [@bettercallzaal](https://warpcast.com/bettercallzaal)